### PR TITLE
fix: isCompleted uses 0-1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -759,7 +759,7 @@ export class QBittorrent implements TorrentClient {
         break;
     }
 
-    const isCompleted = torrent.progress >= 100;
+    const isCompleted = torrent.progress === 1;
 
     const result: NormalizedTorrentQbittorrent = {
       id: torrent.hash,


### PR DESCRIPTION
qBittorrent uses 0-1 to represent the completion of a torrent.